### PR TITLE
Fix tags in discard

### DIFF
--- a/common/src/ioHandler.h
+++ b/common/src/ioHandler.h
@@ -379,10 +379,10 @@ public:
         if (!one.getDiscard() && !two.getDiscard()) {
             pe->write(*per);
         } else if (!one.getDiscard() && !no_orphans) { // Will never be RC
-            one.join_comment(r2.get_comment());
+            one.join_comment(two.get_comment());
             se->write_read(one, false);
         } else if (!two.getDiscard() && !no_orphans) { // if stranded RC
-            two.join_comment(r1.get_comment());
+            two.join_comment(one.get_comment());
             se->write_read(two, stranded);
         }
 

--- a/common/src/ioHandler.h
+++ b/common/src/ioHandler.h
@@ -379,9 +379,11 @@ public:
         if (!one.getDiscard() && !two.getDiscard()) {
             pe->write(*per);
         } else if (!one.getDiscard() && !no_orphans) { // Will never be RC
+            one.join_comment(r2.get_comment());
             se->write_read(one, false);
         } else if (!two.getDiscard() && !no_orphans) { // if stranded RC
-            se->write_read((per->get_read_two()), stranded);
+            two.join_comment(r1.get_comment());
+            se->write_read(two, stranded);
         }
 
     }


### PR DESCRIPTION
Emergency update for the workshop, when reads are discarded any comments/tags from the read are lost (breaks the singlecell workflow), need to add any discarded reads tags to the other read.
