### PR TITLE
Invalid ASCII Char Bug Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.2)
 project (HTStream)
 
-option(BUILD_STATIC_BIN "builds static binary (linux only)" ON)
+option(BUILD_STATIC_BIN "builds static binary (linux only)" OFF)
 option(BUILD_GPERFTOOLS "links to google perftools" OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
@@ -10,7 +10,7 @@ message( status "cmake module path: " ${CMAKE_MODULE_PATH})
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_STATIC_LIBS OFF)
 set(BUILD_SHARED_LIBS ON)
 
 # ignore boost deprication

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.2)
 project (HTStream)
 
-option(BUILD_STATIC_BIN "builds static binary (linux only)" OFF)
+option(BUILD_STATIC_BIN "builds static binary (linux only)" ON)
 option(BUILD_GPERFTOOLS "links to google perftools" OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
@@ -10,7 +10,7 @@ message( status "cmake module path: " ${CMAKE_MODULE_PATH})
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_STATIC_LIBS ON)
 set(BUILD_SHARED_LIBS ON)
 
 # ignore boost deprication

--- a/common/src/counters.h
+++ b/common/src/counters.h
@@ -228,7 +228,7 @@ public:
                 outStats << "\"" << *v << "\"";
             else if (auto v = boost::any_cast<char>(&value)) // options case for chars (hts_ExtractUMI)
                 outStats << "\"" << *v << "\"";
-            else if (auto v = boost::any_cast<bool>(&value))
+            else if (auto v = boost::any_cast<bool>(&value))    
                 outStats << ((*v) ? "true" : "false");
             else if (auto v = boost::any_cast<size_t>(&value))
                 outStats << *v;

--- a/hts_AdapterTrimmer/src/hts_AdapterTrimmer.h
+++ b/hts_AdapterTrimmer/src/hts_AdapterTrimmer.h
@@ -143,7 +143,7 @@ public:
                     r2.changeQual( (r2_len - 1) -  read2_bp, qual);
                 } else {
                     bp = qual1[read1_bp] >= qual2[read2_bp] ? seq1[read1_bp] : seq2[read2_bp];
-                    qual = static_cast<char>(std::max(qual1[read1_bp] - qual2[read2_bp] + qual_offset, 1 + qual_offset));
+                    qual = static_cast<char>(std::min(std::max(qual1[read1_bp] - qual2[read2_bp] + qual_offset, 1 + qual_offset), 40 + qual_offset));
 
                     r1.changeSeq(read1_bp, bp);
                     r1.changeQual(read1_bp, qual);

--- a/hts_ExtractUMI/src/hts_ExtractUMI.h
+++ b/hts_ExtractUMI/src/hts_ExtractUMI.h
@@ -236,7 +236,7 @@ public:
                 }
             }
         }
-                          );
+);
 
         while (reader.has_next()) {
             auto i = reader.next();

--- a/hts_Overlapper/src/hts_Overlapper.h
+++ b/hts_Overlapper/src/hts_Overlapper.h
@@ -177,7 +177,7 @@ public:
                 qual = static_cast<char>(std::min(qual1[read1_bp] + qual2[read2_bp] - qual_offset, 40 + qual_offset)); //addition of qual (minus just one of the ascii values
             } else {
                 bp = qual1[read1_bp] >= qual2[read2_bp] ? seq1[read1_bp] : seq2[read2_bp];
-                qual = static_cast<char>(std::max(qual1[read1_bp] - qual2[read2_bp] + qual_offset, 1 + qual_offset));
+                qual = static_cast<char>(std::min(std::max(qual1[read1_bp] - qual2[read2_bp] + qual_offset, 1 + qual_offset), 40 + qual_offset));
             }
             finalSeq += bp;
             finalQual += qual;


### PR DESCRIPTION
Hey y'all,

So I have a fix in place for the bug we have been seeing. It was introduced somewhere before I had contributed, so hts_ExtractUMI and hts_SuperDeduper are clean as far as I can tell (I was still getting the error at commit c9ae81a85a6e795607fd0533efcc07020c0ac1a2). I narrowed down the issue to hts_AdapterTrimmer (line 180), which did not have an upper bound for the ascii character for one of the conditions when setting the quality score. The situation is unlikely, but to fix it, I simply added the upper bound from the other condition onto the problematic code leaving the original lower bound. Naturally, I made the same change to overlapper as well.

I also created a bioshare for some test data if you want to validate what I am saying (https://bioshare.bioinformatics.ucdavis.edu/bioshare/view/7xi6qmrny2183vc/). 

This fix seemed appropriate, but if there's a reason it doesn't make sense because of how sequencing technology works, I'd love to know. 